### PR TITLE
Add jar to archives

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,3 +16,12 @@ dependencies {
 }
 
 apply from: 'https://raw.githubusercontent.com/jaredrummler/android-artifact-push/master/maven/gradle-mvn-push.gradle'
+
+android.libraryVariants.all { variant ->
+  def name = variant.buildType.name
+  def task = project.tasks.create "jar${name.capitalize()}", Jar
+  task.baseName = project.name + "-" + name
+  task.dependsOn variant.javaCompile
+  task.from variant.javaCompile.destinationDir
+  artifacts.add('archives', task)
+}


### PR DESCRIPTION
- Add compiled `Jar` Task for `debug` and `release` variants
- Output names: `library-debug.jar` and `library-release.jar` just like the output names for the `AAR`s: `library-debug.aar` and `library-release.aar`