### PR TITLE
Only add release builds

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,8 +19,12 @@ apply from: 'https://raw.githubusercontent.com/jaredrummler/android-artifact-pus
 
 android.libraryVariants.all { variant ->
   def name = variant.buildType.name
+  if (name == com.android.builder.core.BuilderConstants.DEBUG) return // Skip debug builds.
   def task = project.tasks.create "jar${name.capitalize()}", Jar
-  task.baseName = project.name + "-" + name
+  task.group = "Publications"
+  task.description = "Create compiled jar of project."
+  task.classifier = "binary"
+  task.baseName = project.name + '-' + name
   task.dependsOn variant.javaCompile
   task.from variant.javaCompile.destinationDir
   artifacts.add('archives', task)


### PR DESCRIPTION
## Issue:
```groovy
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':library:uploadArchives'.
> Could not publish configuration 'archives'
   > A POM cannot have multiple artifacts with the same type and classifier. Already have MavenArtifact html-builder:jar:jar:binary, trying to add MavenArtifact html-builder:jar:jar:binary.
```

## Fix and explanation:
It was going through all variants, adding "debug" and "release" to the archives wit the same "classifier" and type(jar)